### PR TITLE
HOTFIX: .slideToggle() is not toggling .section-settings in admin

### DIFF
--- a/src/planbox_ui/static/scripts/project-editor-v2/project-admin-view.js
+++ b/src/planbox_ui/static/scripts/project-editor-v2/project-admin-view.js
@@ -299,7 +299,9 @@ var Planbox = Planbox || {};
       },
       handleSettingsToggle: function(evt) {
         evt.preventDefault();
-        $(evt.currentTarget).parents('.section-settings-toggle-container').next('.section-settings').slideToggle(400);
+        // $(evt.currentTarget).parents('.section-settings-toggle-container').next('.section-settings').slideToggle(400);
+        // TODO: Investigate when/why slideToggle stopped working. -AC
+        $(evt.currentTarget).parents('.section-settings-toggle-container').next('.section-settings').toggleClass('hide');
       },
       save: function(data) {
         var self = this,


### PR DESCRIPTION
I patched this using .toggleClass() instead, but its root problem needs investigation. Other stuff may be broken/conflicting. 
